### PR TITLE
Fixes New-Object error when host list is empty

### DIFF
--- a/DRSRule.psm1
+++ b/DRSRule.psm1
@@ -82,6 +82,10 @@ Function Get-DrsVMHostGroup
                             {
                               Get-View $_.Host -Property Name | Select-Object -ExpandProperty Name
                             }
+                            else
+                            {
+                              $null
+                            }
                           )
             VMHostId    = $_.Host
             UserCreated = [Boolean]$_.UserCreated


### PR DESCRIPTION
I was getting the following error:

New-Object : The value supplied is not valid, or the property is read-only. Change the value, and then try again.
At C:\scripts\modules\drsrule\DRSRule.psm1:77 char:11
+           New-Object DRSRule.VMHostGroup -Property @{
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidData: (:) [New-Object], Exception
    + FullyQualifiedErrorId : SetValueException,Microsoft.PowerShell.Commands.NewObjectCommand

Not sure if it is due to running PS 5 or PowerCLI 6, but tracked it down to the VMHost property.  I think the old syntax was generating some weird PSObject wrapped $null, which the DRSRule.VMHostGroup object was not able to cast correctly.