### PR TITLE
Fix for non-default install directory

### DIFF
--- a/DRSRule.init.ps1
+++ b/DRSRule.init.ps1
@@ -1,4 +1,5 @@
-﻿$pcliDll = "${env:\ProgramFiles(x86)}\VMware\Infrastructure\vSphere PowerCLI\VMware.Vim.dll"
+﻿$modulePath = (get-module VMware.VimAutomation.Core).path
+﻿$pcliDll = "$($modulePath.substring(0,$modulePath.indexOf('Modules')))VMware.Vim.dll"
 
 Add-Type -ReferencedAssemblies $pcliDll -TypeDefinition @"
   using VMware.Vim;


### PR DESCRIPTION
This will allow the module to work if PowerCLI is installed in a non-default directory (or if the workstation is 32 bit Windows).